### PR TITLE
Remove endowed from genesis

### DIFF
--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -105,8 +105,6 @@ decl_storage! {
 
         Chains: map hasher(blake2_256) Vec<u8> => Option<TxCount>;
 
-        EndowedAccount get(fn endowed) config(): T::AccountId;
-
         RelayerThreshold get(fn relayer_threshold) config(): u32;
 
         pub Relayers get(fn relayers): map hasher(blake2_256) T::AccountId => bool;
@@ -237,10 +235,11 @@ decl_module! {
         }
 
         // TODO: Should use correct amount type
+        // TODO: Move to example-pallet
         pub fn transfer(origin, to: T::AccountId, amount: u32) -> DispatchResult {
             let who = ensure_signed(origin)?;
             ensure!(who == Self::account_id(), Error::<T>::DebugInnerCallFailed);
-            let source: T::AccountId = <EndowedAccount<T>>::get();
+            let source = Self::account_id();
             T::Currency::transfer(&source, &to, amount.into(), AllowDeath)?;
             Ok(())
         }

--- a/chainbridge/src/mock.rs
+++ b/chainbridge/src/mock.rs
@@ -7,7 +7,7 @@ use frame_system::{self as system};
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
-    traits::{BlakeTwo256, Block as BlockT, IdentityLookup},
+    traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, IdentityLookup},
     BuildStorage, Perbill,
 };
 
@@ -81,22 +81,21 @@ frame_support::construct_runtime!(
     }
 );
 
-pub const ENDOWED_ID: u64 = 0x1;
-pub const VALIDATOR_A: u64 = 0x2;
-pub const VALIDATOR_B: u64 = 0x3;
-pub const VALIDATOR_C: u64 = 0x4;
-pub const USER: u64 = 0x4;
-pub const ENDOWED_BALANCE: u64 = 100;
+// pub const BRIDGE_ID: u64 =
+pub const RELAYER_A: u64 = 0x2;
+pub const RELAYER_B: u64 = 0x3;
+pub const RELAYER_C: u64 = 0x4;
+pub const ENDOWED_BALANCE: u64 = 100_000_000;
 
 pub fn new_test_ext(threshold: u32) -> sp_io::TestExternalities {
+    let bridge_id = ModuleId(*b"cb/bridg").into_account();
     GenesisConfig {
         bridge: Some(bridge::GenesisConfig {
-            endowed: ENDOWED_ID,
-            relayers: vec![VALIDATOR_A, VALIDATOR_B, VALIDATOR_C],
+            relayers: vec![RELAYER_A, RELAYER_B, RELAYER_C],
             relayer_threshold: threshold,
         }),
         balances: Some(balances::GenesisConfig {
-            balances: vec![(ENDOWED_ID, ENDOWED_BALANCE)],
+            balances: vec![(bridge_id, ENDOWED_BALANCE)],
         }),
     }
     .build_storage()

--- a/example-pallet/src/mock.rs
+++ b/example-pallet/src/mock.rs
@@ -7,8 +7,8 @@ use frame_system::{self as system};
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
-    traits::{BlakeTwo256, Block as BlockT, IdentityLookup},
-    BuildStorage, Perbill,
+    traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, IdentityLookup},
+    BuildStorage, ModuleId, Perbill,
 };
 
 use crate::{self as example, Trait};
@@ -88,22 +88,20 @@ frame_support::construct_runtime!(
     }
 );
 
-pub const ENDOWED_ID: u64 = 0x1;
-pub const VALIDATOR_A: u64 = 0x2;
-pub const VALIDATOR_B: u64 = 0x3;
-pub const VALIDATOR_C: u64 = 0x4;
-pub const USER: u64 = 0x4;
+pub const RELAYER_A: u64 = 0x2;
+pub const RELAYER_B: u64 = 0x3;
+pub const RELAYER_C: u64 = 0x4;
 pub const ENDOWED_BALANCE: u64 = 100;
 
 pub fn new_test_ext(threshold: u32) -> sp_io::TestExternalities {
+    let bridge_id = ModuleId(*b"cb/bridg").into_account();
     GenesisConfig {
         bridge: Some(bridge::GenesisConfig {
-            endowed: ENDOWED_ID,
-            relayers: vec![VALIDATOR_A, VALIDATOR_B, VALIDATOR_C],
+            relayers: vec![RELAYER_A, RELAYER_B, RELAYER_C],
             relayer_threshold: threshold,
         }),
         balances: Some(balances::GenesisConfig {
-            balances: vec![(ENDOWED_ID, ENDOWED_BALANCE)],
+            balances: vec![(bridge_id, ENDOWED_BALANCE)],
         }),
     }
     .build_storage()

--- a/example-pallet/src/tests.rs
+++ b/example-pallet/src/tests.rs
@@ -1,8 +1,8 @@
 #![cfg(test)]
 
 use super::mock::{
-    expect_event, new_test_ext, Balances, Bridge, Call, Event, Example, Origin, Test,
-    ENDOWED_BALANCE, ENDOWED_ID, USER, VALIDATOR_A, VALIDATOR_B, VALIDATOR_C,
+    expect_event, new_test_ext, Balances, Bridge, Call, Event, Example, Origin, Test, RELAYER_A,
+    RELAYER_B,
 };
 use super::*;
 use frame_support::dispatch::DispatchError;
@@ -48,12 +48,12 @@ fn execute_remark() {
         let prop_id = 1;
 
         assert_ok!(Bridge::create_proposal(
-            Origin::signed(VALIDATOR_A),
+            Origin::signed(RELAYER_A),
             prop_id,
             Box::new(proposal.clone())
         ));
         assert_ok!(Bridge::approve(
-            Origin::signed(VALIDATOR_B),
+            Origin::signed(RELAYER_B),
             prop_id,
             Box::new(proposal.clone())
         ));
@@ -70,7 +70,7 @@ fn execute_remark_bad_origin() {
         assert_ok!(Example::remark(Origin::signed(Bridge::account_id()), hash));
         // Don't allow any signed origin except from bridge addr
         assert_noop!(
-            Example::remark(Origin::signed(VALIDATOR_A), hash),
+            Example::remark(Origin::signed(RELAYER_A), hash),
             DispatchError::BadOrigin
         );
         // Don't allow root calls


### PR DESCRIPTION
No longer needed as we now use the ModuleId to derive an account Id for the bridge.