### PR TITLE
Combine create and approve

### DIFF
--- a/chainbridge/src/tests.rs
+++ b/chainbridge/src/tests.rs
@@ -153,7 +153,7 @@ fn create_sucessful_proposal() {
         assert_eq!(Bridge::relayer_threshold(), 2);
 
         // Create proposal (& vote)
-        assert_ok!(Bridge::create_proposal(
+        assert_ok!(Bridge::acknowledge_proposal(
             Origin::signed(RELAYER_A),
             prop_id,
             Box::new(proposal.clone())
@@ -179,7 +179,7 @@ fn create_sucessful_proposal() {
         assert_eq!(prop, expected);
 
         // Third relayer votes in favour
-        assert_ok!(Bridge::approve(
+        assert_ok!(Bridge::acknowledge_proposal(
             Origin::signed(RELAYER_C),
             prop_id,
             Box::new(proposal.clone())
@@ -211,7 +211,7 @@ fn create_unsucessful_proposal() {
         assert_eq!(Bridge::relayer_threshold(), 2);
 
         // Create proposal (& vote)
-        assert_ok!(Bridge::create_proposal(
+        assert_ok!(Bridge::acknowledge_proposal(
             Origin::signed(RELAYER_A),
             prop_id.clone(),
             Box::new(proposal.clone())

--- a/example-pallet/src/tests.rs
+++ b/example-pallet/src/tests.rs
@@ -52,12 +52,12 @@ fn execute_remark() {
         let proposal = make_remark_proposal(hash.clone());
         let prop_id = 1;
 
-        assert_ok!(Bridge::create_proposal(
+        assert_ok!(Bridge::acknowledge_proposal(
             Origin::signed(RELAYER_A),
             prop_id,
             Box::new(proposal.clone())
         ));
-        assert_ok!(Bridge::approve(
+        assert_ok!(Bridge::acknowledge_proposal(
             Origin::signed(RELAYER_B),
             prop_id,
             Box::new(proposal.clone())
@@ -119,7 +119,7 @@ fn create_sucessful_transfer_proposal() {
         assert_eq!(Bridge::relayer_threshold(), 2);
 
         // Create proposal (& vote)
-        assert_ok!(Bridge::create_proposal(
+        assert_ok!(Bridge::acknowledge_proposal(
             Origin::signed(RELAYER_A),
             prop_id,
             Box::new(proposal.clone())
@@ -145,7 +145,7 @@ fn create_sucessful_transfer_proposal() {
         assert_eq!(prop, expected);
 
         // Third relayer votes in favour
-        assert_ok!(Bridge::approve(
+        assert_ok!(Bridge::acknowledge_proposal(
             Origin::signed(RELAYER_C),
             prop_id,
             Box::new(proposal.clone())


### PR DESCRIPTION
- refactors create and approve to be a single method call
- improves documentation
- simplify transfer function to use origin account id

Closes #24 