### PR TITLE
Replace genesis with init function

### DIFF
--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -242,7 +242,6 @@ decl_module! {
 }
 
 impl<T: Trait> Module<T> {
-
     /// Checks if who is a relayer
     pub fn is_relayer(who: &T::AccountId) -> bool {
         Self::relayers(who)

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -30,9 +30,6 @@ struct TxCount {
 pub struct ProposalVotes<AccountId> {
     pub votes_for: Vec<AccountId>,
     pub votes_against: Vec<AccountId>,
-    // TODO: We may wish to store the Call here. While it is required to access the map internally,
-    // externally we can enumarate the keys which would give us all existing propsoals
-    // but would not reveal the calls.
 }
 
 impl<AccountId> Default for ProposalVotes<AccountId> {
@@ -55,7 +52,7 @@ pub trait Trait: system::Trait {
 decl_event! {
     pub enum Event<T> where <T as frame_system::Trait>::AccountId {
         /// Vote threshold has changed (new_threshold)
-        RelayerThresholdSet(u32),
+        RelayerThresholdChanged(u32),
         /// Chain now available for transfers (chain_id)
         ChainWhitelisted(ChainId),
         /// Relayer added to set
@@ -84,8 +81,16 @@ decl_event! {
 // TODO: Pass params to errors
 decl_error! {
     pub enum Error for Module<T: Trait> {
+        /// Root must call `initialize` to set params
+        NotInitialized,
+
+        AlreadyInitialized,
+        /// Relayer threshold not set
+        ThresholdNotSet,
         /// Provided chain Id is not valid
         InvalidChainId,
+        /// Relayer threshold cannot be 0
+        InvalidThreshold,
         /// Interactions with this chain is not permitted
         ChainNotWhitelisted,
         /// Relayer already in set
@@ -107,15 +112,17 @@ decl_error! {
 
 decl_storage! {
     trait Store for Module<T: Trait> as Bridge {
+        /// If config provided, we can consider this initialized.
+        Initialized get(fn is_initialized): bool;
 
         /// The ChainId for this chain.
-        ChainIdentifier get(fn chain_id) config(): u32;
+        pub ChainIdentifier get(fn chain_id): u32;
 
         /// All whitelisted chains and their respective transaction counts
         Chains: map hasher(blake2_256) ChainId => Option<TxCount>;
 
         /// Number of votes required for a proposal to execute
-        RelayerThreshold get(fn relayer_threshold) config(): u32;
+        RelayerThreshold get(fn relayer_threshold): u32;
 
         /// Tracks current relayer set
         pub Relayers get(fn relayers): map hasher(blake2_256) T::AccountId => bool;
@@ -130,12 +137,6 @@ decl_storage! {
             => Option<ProposalVotes<T::AccountId>>;
 
     }
-    add_extra_genesis {
-        config(relayers): Vec<T::AccountId>;
-        build(|config| {
-            Module::<T>::initialize_relayers(&config.relayers);
-        });
-    }
 }
 
 decl_module! {
@@ -143,18 +144,31 @@ decl_module! {
         // Default method for emitting events
         fn deposit_event() = default;
 
-        /// Sets the address used to identify this chain
+        /// Required to be called upon instantiation if no config is provided.
+        pub fn initialize(origin, threshold: u32, chain_id: ChainId) {
+            ensure_root(origin)?;
+            ensure!(!Self::is_initialized(), Error::<T>::AlreadyInitialized);
+            ensure!(threshold > 0, Error::<T>::InvalidThreshold);
+
+            <ChainIdentifier>::put(chain_id);
+            RelayerThreshold::put(threshold);
+            <Initialized>::put(true);
+        }
+
+        /// Sets the vote threshold for proposals
         pub fn set_threshold(origin, threshold: u32) -> DispatchResult {
             ensure_root(origin)?;
 
+            ensure!(threshold > 0, Error::<T>::InvalidThreshold);
             RelayerThreshold::put(threshold);
-            Self::deposit_event(RawEvent::RelayerThresholdSet(threshold));
+            Self::deposit_event(RawEvent::RelayerThresholdChanged(threshold));
             Ok(())
         }
 
         /// Enables a chain ID as a destination for a bridge transfer
         pub fn whitelist_chain(origin, id: ChainId) -> DispatchResult {
             ensure_root(origin)?;
+            ensure!(Self::is_initialized(), Error::<T>::NotInitialized);
 
             // Cannot whitelist this chain
             ensure!(id != Self::chain_id(), Error::<T>::InvalidChainId);
@@ -192,8 +206,8 @@ decl_module! {
         pub fn acknowledge_proposal(origin, prop_id: u32, call: Box<<T as Trait>::Proposal>) -> DispatchResult {
             let who = ensure_signed(origin)?;
             ensure!(Self::is_relayer(&who), Error::<T>::MustBeRelayer);
+            ensure!(Self::is_initialized(), Error::<T>::NotInitialized);
 
-            // Creating a proposal also votes for it
             Self::vote_for(who, prop_id, call)
         }
 
@@ -202,19 +216,16 @@ decl_module! {
         pub fn reject(origin, prop_id: u32, call: Box<<T as Trait>::Proposal>) -> DispatchResult {
             let who = ensure_signed(origin)?;
             ensure!(Self::is_relayer(&who), Error::<T>::MustBeRelayer);
+            ensure!(Self::is_initialized(), Error::<T>::NotInitialized);
 
-            // Make sure proposal exists
-            ensure!(<Votes<T>>::contains_key((prop_id, call.clone())), Error::<T>::ProposalDoesNotExist);
-
-            Self::vote_against(who, prop_id, call)?;
-
-            Ok(())
+            Self::vote_against(who, prop_id, call)
         }
 
         /// Completes an asset transfer to the chain by emitting an event to be acted on by the
         /// bridge and updating the tx count for the respective chan.
         pub fn receive_asset(origin, dest_id: ChainId, to: Vec<u8>, token_id: Vec<u8>, metadata: Vec<u8>) -> DispatchResult {
             ensure_root(origin)?;
+            ensure!(Self::is_initialized(), Error::<T>::NotInitialized);
 
             // Ensure chain is whitelisted
             if let Some(mut counter) = Chains::get(&dest_id) {
@@ -231,19 +242,10 @@ decl_module! {
 }
 
 impl<T: Trait> Module<T> {
+
     /// Checks if who is a relayer
     pub fn is_relayer(who: &T::AccountId) -> bool {
         Self::relayers(who)
-    }
-
-    /// Used for genesis config of relayer set
-    fn initialize_relayers(relayers: &[T::AccountId]) {
-        if !relayers.is_empty() {
-            for v in relayers {
-                <Relayers<T>>::insert(v, true);
-            }
-            <RelayerCount>::put(relayers.len() as u32);
-        }
     }
 
     /// Provides an AccountId for the pallet.

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -83,7 +83,7 @@ decl_error! {
     pub enum Error for Module<T: Trait> {
         /// Root must call `initialize` to set params
         NotInitialized,
-
+        /// Initialization has already been done
         AlreadyInitialized,
         /// Relayer threshold not set
         ThresholdNotSet,
@@ -112,7 +112,7 @@ decl_error! {
 
 decl_storage! {
     trait Store for Module<T: Trait> as Bridge {
-        /// If config provided, we can consider this initialized.
+        /// Whether the initialize function has been called (ie. chain ID and threshold set)
         Initialized get(fn is_initialized): bool;
 
         /// The ChainId for this chain.
@@ -141,10 +141,9 @@ decl_storage! {
 
 decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-        // Default method for emitting events
         fn deposit_event() = default;
 
-        /// Required to be called upon instantiation if no config is provided.
+        /// Sets chain ID and threshold, and enables transfers
         pub fn initialize(origin, threshold: u32, chain_id: ChainId) {
             ensure_root(origin)?;
             ensure!(!Self::is_initialized(), Error::<T>::AlreadyInitialized);

--- a/chainbridge/src/mock.rs
+++ b/chainbridge/src/mock.rs
@@ -77,7 +77,7 @@ frame_support::construct_runtime!(
     {
         System: system::{Module, Call, Event<T>},
         Balances: balances::{Module, Call, Storage, Config<T>, Event<T>},
-        Bridge: bridge::{Module, Call, Storage, Event<T>, Config<T>},
+        Bridge: bridge::{Module, Call, Storage, Event<T>},
     }
 );
 
@@ -87,14 +87,9 @@ pub const RELAYER_B: u64 = 0x3;
 pub const RELAYER_C: u64 = 0x4;
 pub const ENDOWED_BALANCE: u64 = 100_000_000;
 
-pub fn new_test_ext(threshold: u32) -> sp_io::TestExternalities {
+pub fn new_test_ext() -> sp_io::TestExternalities {
     let bridge_id = ModuleId(*b"cb/bridg").into_account();
     GenesisConfig {
-        bridge: Some(bridge::GenesisConfig {
-            chain_id: 1,
-            relayers: vec![RELAYER_A, RELAYER_B, RELAYER_C],
-            relayer_threshold: threshold,
-        }),
         balances: Some(balances::GenesisConfig {
             balances: vec![(bridge_id, ENDOWED_BALANCE)],
         }),

--- a/chainbridge/src/tests.rs
+++ b/chainbridge/src/tests.rs
@@ -9,26 +9,46 @@ use frame_support::{assert_noop, assert_ok};
 
 type System = frame_system::Module<Test>;
 
+const TEST_THRESHOLD: u32 = 2;
+const TEST_CHAIN_ID: u32 = 5;
+
 #[test]
-fn genesis_relayers_generated() {
-    new_test_ext(2).execute_with(|| {
-        System::set_block_number(1);
-        assert_eq!(<ChainIdentifier>::get(), 1);
-        assert_eq!(<Relayers<Test>>::get(RELAYER_A), true);
-        assert_eq!(<Relayers<Test>>::get(RELAYER_B), true);
-        assert_eq!(<Relayers<Test>>::get(RELAYER_C), true);
-        assert_eq!(<RelayerCount>::get(), 3);
-        assert_eq!(<RelayerThreshold>::get(), 2);
-        assert_eq!(
-            Balances::free_balance(Bridge::account_id()),
-            ENDOWED_BALANCE
-        );
-    });
+fn initialize_chain() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
+
+        let prop_id = 1;
+        let proposal = make_proposal(vec![10]);
+        let dest_id = 2;
+        let to = vec![2];
+        let token_id = vec![3];
+        let metadata = vec![];
+
+        assert_noop!(Bridge::acknowledge_proposal(
+            Origin::signed(RELAYER_A),
+            prop_id,
+            Box::new(proposal.clone())
+        ), Error::<Test>::NotInitialized);
+
+        assert_noop!(Bridge::receive_asset(
+            Origin::ROOT,
+            dest_id.clone(),
+            to.clone(),
+            token_id.clone(),
+            metadata.clone()
+        ), Error::<Test>::NotInitialized);
+
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+    })
 }
 
 #[test]
 fn whitelist_chain() {
-    new_test_ext(1).execute_with(|| {
+    new_test_ext().execute_with(|| {
+        assert_noop!(Bridge::whitelist_chain(Origin::ROOT, 0), Error::<Test>::NotInitialized);
+
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+
         assert_ok!(Bridge::whitelist_chain(Origin::ROOT, 0));
         assert_noop!(
             Bridge::whitelist_chain(Origin::ROOT, Bridge::chain_id()),
@@ -41,23 +61,29 @@ fn whitelist_chain() {
 
 #[test]
 fn set_get_threshold() {
-    new_test_ext(1).execute_with(|| {
-        assert_eq!(<RelayerThreshold>::get(), 1);
+    new_test_ext().execute_with(|| {
+        assert_eq!(<RelayerThreshold>::get(), 0);
+
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_eq!(<RelayerThreshold>::get(), TEST_THRESHOLD);
+
 
         assert_ok!(Bridge::set_threshold(Origin::ROOT, 5));
         assert_eq!(<RelayerThreshold>::get(), 5);
 
-        assert_events(vec![Event::bridge(RawEvent::RelayerThresholdSet(5))]);
+        assert_events(vec![Event::bridge(RawEvent::RelayerThresholdChanged(5))]);
     })
 }
 
 #[test]
 fn asset_transfer_success() {
-    new_test_ext(1).execute_with(|| {
+    new_test_ext().execute_with(|| {
         let dest_id = 2;
         let to = vec![2];
         let token_id = vec![3];
         let metadata = vec![];
+
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
 
         assert_ok!(Bridge::whitelist_chain(Origin::ROOT, dest_id.clone()));
         assert_ok!(Bridge::receive_asset(
@@ -82,12 +108,14 @@ fn asset_transfer_success() {
 
 #[test]
 fn asset_transfer_invalid_chain() {
-    new_test_ext(1).execute_with(|| {
+    new_test_ext().execute_with(|| {
         let chain_id = 2;
         let to = vec![2];
         let bad_dest_id = 3;
         let token_id = vec![4];
         let metadata = vec![];
+
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
 
         assert_ok!(Bridge::whitelist_chain(Origin::ROOT, chain_id.clone()));
         assert_noop!(
@@ -108,33 +136,35 @@ fn asset_transfer_invalid_chain() {
 
 #[test]
 fn add_remove_relayer() {
-    new_test_ext(1).execute_with(|| {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_eq!(Bridge::relayer_count(), 0);
+
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_B));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_C));
         assert_eq!(Bridge::relayer_count(), 3);
+
         // Already exists
         assert_noop!(
             Bridge::add_relayer(Origin::ROOT, RELAYER_A),
             Error::<Test>::RelayerAlreadyExists
         );
 
-        // Errors if added twice
-        assert_ok!(Bridge::add_relayer(Origin::ROOT, 99));
-        assert_eq!(Bridge::relayer_count(), 4);
-        assert_noop!(
-            Bridge::add_relayer(Origin::ROOT, 99),
-            Error::<Test>::RelayerAlreadyExists
-        );
-
         // Confirm removal
-        assert_ok!(Bridge::remove_relayer(Origin::ROOT, 99));
-        assert_eq!(Bridge::relayer_count(), 3);
+        assert_ok!(Bridge::remove_relayer(Origin::ROOT, RELAYER_B));
+        assert_eq!(Bridge::relayer_count(), 2);
         assert_noop!(
-            Bridge::remove_relayer(Origin::ROOT, 99),
+            Bridge::remove_relayer(Origin::ROOT, RELAYER_B),
             Error::<Test>::RelayerInvalid
         );
+        assert_eq!(Bridge::relayer_count(), 2);
 
         assert_events(vec![
-            Event::bridge(RawEvent::RelayerAdded(99)),
-            Event::bridge(RawEvent::RelayerRemoved(99)),
+            Event::bridge(RawEvent::RelayerAdded(RELAYER_A)),
+            Event::bridge(RawEvent::RelayerAdded(RELAYER_B)),
+            Event::bridge(RawEvent::RelayerAdded(RELAYER_C)),
+            Event::bridge(RawEvent::RelayerRemoved(RELAYER_B)),
         ]);
     })
 }
@@ -145,11 +175,14 @@ fn make_proposal(r: Vec<u8>) -> mock::Call {
 
 #[test]
 fn create_sucessful_proposal() {
-    new_test_ext(2).execute_with(|| {
+    new_test_ext().execute_with(|| {
         let prop_id = 1;
-
         let proposal = make_proposal(vec![10]);
 
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_B));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_C));
         assert_eq!(Bridge::relayer_threshold(), 2);
 
         // Create proposal (& vote)
@@ -203,12 +236,14 @@ fn create_sucessful_proposal() {
 
 #[test]
 fn create_unsucessful_proposal() {
-    new_test_ext(2).execute_with(|| {
+    new_test_ext().execute_with(|| {
         let prop_id = 1;
-
         let proposal = make_proposal(vec![11]);
 
-        assert_eq!(Bridge::relayer_threshold(), 2);
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_B));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_C));
 
         // Create proposal (& vote)
         assert_ok!(Bridge::acknowledge_proposal(

--- a/chainbridge/src/tests.rs
+++ b/chainbridge/src/tests.rs
@@ -24,30 +24,47 @@ fn initialize_chain() {
         let token_id = vec![3];
         let metadata = vec![];
 
-        assert_noop!(Bridge::acknowledge_proposal(
-            Origin::signed(RELAYER_A),
-            prop_id,
-            Box::new(proposal.clone())
-        ), Error::<Test>::NotInitialized);
+        assert_noop!(
+            Bridge::acknowledge_proposal(
+                Origin::signed(RELAYER_A),
+                prop_id,
+                Box::new(proposal.clone())
+            ),
+            Error::<Test>::NotInitialized
+        );
 
-        assert_noop!(Bridge::receive_asset(
+        assert_noop!(
+            Bridge::receive_asset(
+                Origin::ROOT,
+                dest_id.clone(),
+                to.clone(),
+                token_id.clone(),
+                metadata.clone()
+            ),
+            Error::<Test>::NotInitialized
+        );
+
+        assert_ok!(Bridge::initialize(
             Origin::ROOT,
-            dest_id.clone(),
-            to.clone(),
-            token_id.clone(),
-            metadata.clone()
-        ), Error::<Test>::NotInitialized);
-
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
     })
 }
 
 #[test]
 fn whitelist_chain() {
     new_test_ext().execute_with(|| {
-        assert_noop!(Bridge::whitelist_chain(Origin::ROOT, 0), Error::<Test>::NotInitialized);
+        assert_noop!(
+            Bridge::whitelist_chain(Origin::ROOT, 0),
+            Error::<Test>::NotInitialized
+        );
 
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
 
         assert_ok!(Bridge::whitelist_chain(Origin::ROOT, 0));
         assert_noop!(
@@ -64,9 +81,12 @@ fn set_get_threshold() {
     new_test_ext().execute_with(|| {
         assert_eq!(<RelayerThreshold>::get(), 0);
 
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
         assert_eq!(<RelayerThreshold>::get(), TEST_THRESHOLD);
-
 
         assert_ok!(Bridge::set_threshold(Origin::ROOT, 5));
         assert_eq!(<RelayerThreshold>::get(), 5);
@@ -83,7 +103,11 @@ fn asset_transfer_success() {
         let token_id = vec![3];
         let metadata = vec![];
 
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
 
         assert_ok!(Bridge::whitelist_chain(Origin::ROOT, dest_id.clone()));
         assert_ok!(Bridge::receive_asset(
@@ -115,7 +139,11 @@ fn asset_transfer_invalid_chain() {
         let token_id = vec![4];
         let metadata = vec![];
 
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
 
         assert_ok!(Bridge::whitelist_chain(Origin::ROOT, chain_id.clone()));
         assert_noop!(
@@ -137,7 +165,11 @@ fn asset_transfer_invalid_chain() {
 #[test]
 fn add_remove_relayer() {
     new_test_ext().execute_with(|| {
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
         assert_eq!(Bridge::relayer_count(), 0);
 
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
@@ -179,7 +211,11 @@ fn create_sucessful_proposal() {
         let prop_id = 1;
         let proposal = make_proposal(vec![10]);
 
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_B));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_C));
@@ -240,7 +276,11 @@ fn create_unsucessful_proposal() {
         let prop_id = 1;
         let proposal = make_proposal(vec![11]);
 
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_B));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_C));

--- a/example-pallet/src/mock.rs
+++ b/example-pallet/src/mock.rs
@@ -83,7 +83,7 @@ frame_support::construct_runtime!(
     {
         System: system::{Module, Call, Event<T>},
         Balances: balances::{Module, Call, Storage, Config<T>, Event<T>},
-        Bridge: bridge::{Module, Call, Storage, Event<T>, Config<T>},
+        Bridge: bridge::{Module, Call, Storage, Event<T>},
         Example: example::{Module, Call, Event<T>}
     }
 );
@@ -93,14 +93,9 @@ pub const RELAYER_B: u64 = 0x3;
 pub const RELAYER_C: u64 = 0x4;
 pub const ENDOWED_BALANCE: u64 = 100;
 
-pub fn new_test_ext(threshold: u32) -> sp_io::TestExternalities {
+pub fn new_test_ext() -> sp_io::TestExternalities {
     let bridge_id = ModuleId(*b"cb/bridg").into_account();
     GenesisConfig {
-        bridge: Some(bridge::GenesisConfig {
-            chain_id: 1,
-            relayers: vec![RELAYER_A, RELAYER_B, RELAYER_C],
-            relayer_threshold: threshold,
-        }),
         balances: Some(balances::GenesisConfig {
             balances: vec![(bridge_id, ENDOWED_BALANCE)],
         }),

--- a/example-pallet/src/tests.rs
+++ b/example-pallet/src/tests.rs
@@ -11,6 +11,9 @@ use frame_support::{assert_noop, assert_ok};
 use codec::Encode;
 use sp_core::{blake2_256, H256};
 
+const TEST_THRESHOLD: u32 = 2;
+const TEST_CHAIN_ID: u32 = 5;
+
 fn make_remark_proposal(hash: H256) -> Call {
     Call::Example(crate::Call::remark(hash))
 }
@@ -21,11 +24,13 @@ fn make_transfer_proposal(to: u64, amount: u32) -> Call {
 
 #[test]
 fn transfer_hash() {
-    new_test_ext(2).execute_with(|| {
+    new_test_ext().execute_with(|| {
         let dest_chain = 0;
         let token_id = vec![1];
         let hash: H256 = "ABC".using_encoded(blake2_256).into();
         let recipient = vec![99];
+
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
 
         assert_ok!(Bridge::whitelist_chain(Origin::ROOT, dest_chain.clone()));
         assert_ok!(Example::transfer_hash(
@@ -47,10 +52,14 @@ fn transfer_hash() {
 
 #[test]
 fn execute_remark() {
-    new_test_ext(2).execute_with(|| {
+    new_test_ext().execute_with(|| {
         let hash: H256 = "ABC".using_encoded(blake2_256).into();
         let proposal = make_remark_proposal(hash.clone());
         let prop_id = 1;
+
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_B));
 
         assert_ok!(Bridge::acknowledge_proposal(
             Origin::signed(RELAYER_A),
@@ -69,8 +78,10 @@ fn execute_remark() {
 
 #[test]
 fn execute_remark_bad_origin() {
-    new_test_ext(2).execute_with(|| {
+    new_test_ext().execute_with(|| {
         let hash: H256 = "ABC".using_encoded(blake2_256).into();
+
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
 
         assert_ok!(Example::remark(Origin::signed(Bridge::account_id()), hash));
         // Don't allow any signed origin except from bridge addr
@@ -88,7 +99,8 @@ fn execute_remark_bad_origin() {
 
 #[test]
 fn transfer() {
-    new_test_ext(1).execute_with(|| {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
         // Check inital state
         let bridge_id: u64 = Bridge::account_id();
         assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE);
@@ -111,10 +123,14 @@ fn transfer() {
 
 #[test]
 fn create_sucessful_transfer_proposal() {
-    new_test_ext(2).execute_with(|| {
+    new_test_ext().execute_with(|| {
         let prop_id = 1;
-
         let proposal = make_transfer_proposal(RELAYER_A, 10);
+
+        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_B));
+        assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_C));
 
         assert_eq!(Bridge::relayer_threshold(), 2);
 

--- a/example-pallet/src/tests.rs
+++ b/example-pallet/src/tests.rs
@@ -30,7 +30,11 @@ fn transfer_hash() {
         let hash: H256 = "ABC".using_encoded(blake2_256).into();
         let recipient = vec![99];
 
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
 
         assert_ok!(Bridge::whitelist_chain(Origin::ROOT, dest_chain.clone()));
         assert_ok!(Example::transfer_hash(
@@ -57,7 +61,11 @@ fn execute_remark() {
         let proposal = make_remark_proposal(hash.clone());
         let prop_id = 1;
 
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_B));
 
@@ -81,7 +89,11 @@ fn execute_remark_bad_origin() {
     new_test_ext().execute_with(|| {
         let hash: H256 = "ABC".using_encoded(blake2_256).into();
 
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
 
         assert_ok!(Example::remark(Origin::signed(Bridge::account_id()), hash));
         // Don't allow any signed origin except from bridge addr
@@ -100,7 +112,11 @@ fn execute_remark_bad_origin() {
 #[test]
 fn transfer() {
     new_test_ext().execute_with(|| {
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
         // Check inital state
         let bridge_id: u64 = Bridge::account_id();
         assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE);
@@ -127,7 +143,11 @@ fn create_sucessful_transfer_proposal() {
         let prop_id = 1;
         let proposal = make_transfer_proposal(RELAYER_A, 10);
 
-        assert_ok!(Bridge::initialize(Origin::ROOT, TEST_THRESHOLD, TEST_CHAIN_ID));
+        assert_ok!(Bridge::initialize(
+            Origin::ROOT,
+            TEST_THRESHOLD,
+            TEST_CHAIN_ID
+        ));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_A));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_B));
         assert_ok!(Bridge::add_relayer(Origin::ROOT, RELAYER_C));


### PR DESCRIPTION
- Removes usage of genesis config
- Adds `initialize` function and checks
- Updates tests

Closes #29 