### PR TITLE
Update fungible amount types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "serde",
+ "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/chainbridge/Cargo.toml
+++ b/chainbridge/Cargo.toml
@@ -19,6 +19,7 @@ sp-core = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/subs
 frame-support = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/substrate.git", rev = "013c1ee167354a08283fb69915fda56a62fee943", default-features = false }
 frame-system = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/substrate.git", rev = "013c1ee167354a08283fb69915fda56a62fee943", default-features = false }
 
+[dev-dependencies]
 pallet-balances = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/substrate.git", rev = "013c1ee167354a08283fb69915fda56a62fee943", default-features = false }
 
 [build-dependencies]

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -5,13 +5,13 @@ use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
     dispatch::DispatchResult,
     ensure,
-    traits::Currency,
     traits::Get,
     weights::{FunctionOf, GetDispatchInfo, SimpleDispatchInfo},
     Parameter,
 };
 
 use frame_system::{self as system, ensure_root, ensure_signed};
+use sp_core::U256;
 use sp_runtime::traits::{AccountIdConversion, Dispatchable, EnsureOrigin};
 use sp_runtime::{ModuleId, RuntimeDebug};
 use sp_std::prelude::*;
@@ -87,8 +87,6 @@ impl<AccountId> Default for ProposalVotes<AccountId> {
 
 pub trait Trait: system::Trait {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
-    /// The currency mechanism.
-    type Currency: Currency<Self::AccountId>;
     /// Proposed dispatchable call
     type Proposal: Parameter + Dispatchable<Origin = Self::Origin> + EncodeLike + GetDispatchInfo;
     /// The identifier for this chain.
@@ -107,7 +105,7 @@ decl_event! {
         /// Relayer removed from set
         RelayerRemoved(AccountId),
         /// FunglibleTransfer is for relaying fungibles (dest_id, nonce, resource_id, amount, recipient, metadata)
-        FungibleTransfer(ChainId, DepositNonce, ResourceId, u32, Vec<u8>),
+        FungibleTransfer(ChainId, DepositNonce, ResourceId, U256, Vec<u8>),
         /// NonFungibleTransfer is for relaying NFTS (dest_id, nonce, resource_id, token_id, recipient, metadata)
         NonFungibleTransfer(ChainId, DepositNonce, ResourceId, Vec<u8>, Vec<u8>, Vec<u8>),
         /// GenericTransfer is for a generic data payload (dest_id, nonce, resource_id, metadata)
@@ -447,7 +445,7 @@ impl<T: Trait> Module<T> {
         dest_id: ChainId,
         resource_id: ResourceId,
         to: Vec<u8>,
-        amount: u32,
+        amount: U256,
     ) -> DispatchResult {
         ensure!(
             Self::chain_whitelisted(dest_id),

--- a/chainbridge/src/mock.rs
+++ b/chainbridge/src/mock.rs
@@ -65,8 +65,6 @@ parameter_types! {
 
 impl Trait for Test {
     type Event = Event;
-    type Currency = Balances;
-    // type ValidatorOrigin = EnsureSignedBy<One, u64>;
     type Proposal = Call;
     type ChainId = TestChainId;
 }

--- a/chainbridge/src/tests.rs
+++ b/chainbridge/src/tests.rs
@@ -91,7 +91,7 @@ fn asset_transfer_success() {
             dest_id.clone(),
             resource_id.clone(),
             to.clone(),
-            amount
+            amount.into()
         ));
         assert_events(vec![
             Event::bridge(RawEvent::ChainWhitelisted(dest_id.clone())),
@@ -99,7 +99,7 @@ fn asset_transfer_success() {
                 dest_id.clone(),
                 1,
                 resource_id.clone(),
-                amount,
+                amount.into(),
                 to.clone(),
             )),
         ]);
@@ -147,7 +147,7 @@ fn asset_transfer_invalid_chain() {
         ))]);
 
         assert_noop!(
-            Bridge::transfer_fungible(bad_dest_id, resource_id.clone(), vec![], 0,),
+            Bridge::transfer_fungible(bad_dest_id, resource_id.clone(), vec![], U256::zero()),
             Error::<Test>::ChainNotWhitelisted
         );
 

--- a/example-pallet/Cargo.toml
+++ b/example-pallet/Cargo.toml
@@ -14,6 +14,7 @@ sp-std = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/subst
 sp-runtime = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/substrate.git", rev = "013c1ee167354a08283fb69915fda56a62fee943", default-features = false }
 sp-io = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/substrate.git", rev = "013c1ee167354a08283fb69915fda56a62fee943", default-features = false }
 sp-core = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/substrate.git", rev = "013c1ee167354a08283fb69915fda56a62fee943", default-features = false }
+sp-arithmetic = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/substrate.git", rev = "013c1ee167354a08283fb69915fda56a62fee943", default-features = false }
 
 # frame dependencies
 frame-support = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/substrate.git", rev = "013c1ee167354a08283fb69915fda56a62fee943", default-features = false }
@@ -21,7 +22,6 @@ frame-system = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech
 
 chainbridge = { path = "../chainbridge" , default-features = false}
 example-erc721 = { path = "../example-erc721", default-features = false }
-
 
 [dev-dependencies]
 pallet-balances = { version = "2.0.0-alpha.3", git = "https://github.com/paritytech/substrate.git", rev = "013c1ee167354a08283fb69915fda56a62fee943", default-features = false }
@@ -37,6 +37,7 @@ std = [
 	"sp-runtime/std",
     "sp-io/std",
     "sp-core/std",
+    "sp-arithmetic/std",
 	"frame-support/std",
 	"frame-system/std",
 	"chainbridge/std",

--- a/example-pallet/src/mock.rs
+++ b/example-pallet/src/mock.rs
@@ -67,8 +67,6 @@ parameter_types! {
 
 impl bridge::Trait for Test {
     type Event = Event;
-    type Currency = Balances;
-    // type ValidatorOrigin = EnsureSignedBy<One, u64>;
     type Proposal = Call;
     type ChainId = TestChainId;
 }
@@ -87,6 +85,7 @@ impl erc721::Trait for Test {
 impl Trait for Test {
     type Event = Event;
     type BridgeOrigin = bridge::EnsureBridge<Test>;
+    type Currency = Balances;
     type HashId = HashId;
     type NativeTokenId = NativeTokenId;
     type Erc721Id = Erc721Id;

--- a/example-pallet/src/tests.rs
+++ b/example-pallet/src/tests.rs
@@ -19,8 +19,8 @@ fn make_remark_proposal(hash: H256) -> Call {
     Call::Example(crate::Call::remark(hash))
 }
 
-fn make_transfer_proposal(to: u64, amount: u32) -> Call {
-    Call::Example(crate::Call::transfer(to, amount))
+fn make_transfer_proposal(to: u64, amount: u64) -> Call {
+    Call::Example(crate::Call::transfer(to, amount.into()))
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn transfer_native() {
     new_test_ext().execute_with(|| {
         let dest_chain = 0;
         let resource_id = NativeTokenId::get();
-        let amount: u32 = 100;
+        let amount: u64 = 100;
         let recipient = vec![99];
 
         assert_ok!(Bridge::whitelist_chain(Origin::ROOT, dest_chain.clone()));
@@ -68,7 +68,7 @@ fn transfer_native() {
             dest_chain,
             1,
             resource_id,
-            amount,
+            amount.into(),
             recipient,
         ));
     })


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Replaces `u32` with `U256` in bridge pallet, to assert a maximum size of 256bits that is not dependent on the actual size of balances
- Remove currency trait from chainbridge as it's not explicitly necessary and reduces assumptions about the containing runtime
- Adds Currency trait to example pallet for transfers, saturates into U256 for calls into the bridge pallet

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #44 
