### PR TITLE
Add admin origin

### DIFF
--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -10,7 +10,7 @@ use frame_support::{
     Parameter,
 };
 
-use frame_system::{self as system, ensure_signed};
+use frame_system::{self as system, ensure_signed, ensure_root};
 use sp_core::U256;
 use sp_runtime::traits::{AccountIdConversion, Dispatchable, EnsureOrigin};
 use sp_runtime::{ModuleId, RuntimeDebug};
@@ -202,7 +202,7 @@ decl_module! {
         /// # </weight>
         #[weight = SimpleDispatchInfo::FixedNormal(500_000)]
         pub fn set_threshold(origin, threshold: u32) -> DispatchResult {
-            ensure_root(origin)?;
+            Self::ensure_admin(origin)?;
             Self::set_relayer_threshold(threshold)
         }
 
@@ -213,7 +213,7 @@ decl_module! {
         /// # </weight>
         #[weight = SimpleDispatchInfo::FixedNormal(500_000)]
         pub fn set_resource(origin, id: ResourceId, method: Vec<u8>) -> DispatchResult {
-            ensure_root(origin)?;
+            Self::ensure_admin(origin)?;
             Self::register_resource(id, method)
         }
 
@@ -227,7 +227,7 @@ decl_module! {
         /// # </weight>
         #[weight = SimpleDispatchInfo::FixedNormal(500_000)]
         pub fn remove_resource(origin, id: ResourceId) -> DispatchResult {
-            ensure_root(origin)?;
+            Self::ensure_admin(origin)?;
             Self::unregister_resource(id)
         }
 
@@ -238,7 +238,7 @@ decl_module! {
         /// # </weight>
         #[weight = SimpleDispatchInfo::FixedNormal(500_000)]
         pub fn whitelist_chain(origin, id: ChainId) -> DispatchResult {
-            ensure_root(origin)?;
+            Self::ensure_admin(origin)?;
             Self::whitelist(id)
         }
 
@@ -249,7 +249,7 @@ decl_module! {
         /// # </weight>
         #[weight = SimpleDispatchInfo::FixedNormal(500_000)]
         pub fn add_relayer(origin, v: T::AccountId) -> DispatchResult {
-            ensure_root(origin)?;
+            Self::ensure_admin(origin)?;
             Self::register_relayer(v)
         }
 
@@ -260,7 +260,7 @@ decl_module! {
         /// # </weight>
         #[weight = SimpleDispatchInfo::FixedNormal(500_000)]
         pub fn remove_relayer(origin, v: T::AccountId) -> DispatchResult {
-            ensure_root(origin)?;
+            Self::ensure_admin(origin)?;
             Self::unregister_relayer(v)
         }
 
@@ -307,6 +307,13 @@ decl_module! {
 
 impl<T: Trait> Module<T> {
     // *** Utility methods ***
+
+    pub fn ensure_admin(o: T::Origin) -> DispatchResult {
+        T::AdminOrigin::try_origin(o)
+            .map(|_| ())
+            .or_else(ensure_root)?;
+        Ok(())
+    }
 
     /// Checks if who is a relayer
     pub fn is_relayer(who: &T::AccountId) -> bool {

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -10,7 +10,7 @@ use frame_support::{
     Parameter,
 };
 
-use frame_system::{self as system, ensure_signed, ensure_root};
+use frame_system::{self as system, ensure_root, ensure_signed};
 use sp_core::U256;
 use sp_runtime::traits::{AccountIdConversion, Dispatchable, EnsureOrigin};
 use sp_runtime::{ModuleId, RuntimeDebug};

--- a/chainbridge/src/mock.rs
+++ b/chainbridge/src/mock.rs
@@ -65,6 +65,7 @@ parameter_types! {
 
 impl Trait for Test {
     type Event = Event;
+    type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
     type Proposal = Call;
     type ChainId = TestChainId;
 }

--- a/example-pallet/src/mock.rs
+++ b/example-pallet/src/mock.rs
@@ -67,6 +67,7 @@ parameter_types! {
 
 impl bridge::Trait for Test {
     type Event = Event;
+    type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
     type Proposal = Call;
     type ChainId = TestChainId;
 }


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Adds origin type to chainbridge pallet
- Replaces usage of `ensure_root` with new origin type
- Use root as fallback for admin origin check

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #48 
