### PR TITLE
runtime benchmarks feature and extra method for EnsureOrigin added

### DIFF
--- a/chainbridge/Cargo.toml
+++ b/chainbridge/Cargo.toml
@@ -36,3 +36,7 @@ std = [
 	"frame-system/std",
 	"pallet-balances/std",
 ]
+runtime-benchmarks = [
+	"frame-system/runtime-benchmarks",
+	"frame-support/runtime-benchmarks"
+]

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -613,4 +613,15 @@ impl<T: Config> EnsureOrigin<T::Origin> for EnsureBridge<T> {
             r => Err(T::Origin::from(r)),
         })
     }
+
+    /// Returns an outer origin capable of passing `try_origin` check.
+    ///
+    /// ** Should be used for benchmarking only!!! **
+    #[cfg(feature = "runtime-benchmarks")]
+    fn successful_origin() -> T::Origin {
+        T::Origin::from(
+            frame_system::RawOrigin::Signed(<Module<T>>::account_id())
+        )
+    }
+
 }

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -619,7 +619,6 @@ impl<T: Config> EnsureOrigin<T::Origin> for EnsureBridge<T> {
     /// ** Should be used for benchmarking only!!! **
     #[cfg(feature = "runtime-benchmarks")]
     fn successful_origin() -> T::Origin {
-        use frame_support::traits::OriginTrait;
         T::Origin::from(
             frame_system::RawOrigin::Signed(<Module<T>>::account_id())
         )

--- a/chainbridge/src/lib.rs
+++ b/chainbridge/src/lib.rs
@@ -619,6 +619,7 @@ impl<T: Config> EnsureOrigin<T::Origin> for EnsureBridge<T> {
     /// ** Should be used for benchmarking only!!! **
     #[cfg(feature = "runtime-benchmarks")]
     fn successful_origin() -> T::Origin {
+        use frame_support::traits::OriginTrait;
         T::Origin::from(
             frame_system::RawOrigin::Signed(<Module<T>>::account_id())
         )


### PR DESCRIPTION

Adds fix allowing pallet to be included in runtimes with the `runtime-benchmarks` flag set

## Description
- Adds the required method behind a `#[cfg(feature = "runtime-benchmarks")]` annotation
- Adds the feature to the Cargo.toml

## Related Issue Or Context

Closes: #100 

## How Has This Been Tested? Testing details.

Testing requires building with different feature flags. Requesting feedback for if this is worth adding to the CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ x] I have ensured that all the checks are passing and green, I've signed the CLA bot
